### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,5 +1,8 @@
 name: CI - Validation
 
+permissions:
+  contents: read
+
 on:
   push:
     paths-ignore: 


### PR DESCRIPTION
Potential fix for [https://github.com/albert-mueller/OpenCore-Legacy-Patcher-T2/security/code-scanning/2](https://github.com/albert-mueller/OpenCore-Legacy-Patcher-T2/security/code-scanning/2)

Add an explicit `permissions` block to the workflow so the `GITHUB_TOKEN` is least-privileged by default.

Best fix here (without changing functionality): add workflow-level permissions just below `name` (or below `on`) with:
- `contents: read`

This is sufficient for `actions/checkout@v4` and a read-only validation run, and applies to all jobs unless overridden later.  
File to edit: `.github/workflows/validate.yml` in the top-level section before `jobs:`.

No new imports, methods, or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
