### PR TITLE
Update Github runners for CI/CD

### DIFF
--- a/.github/workflows/build-app-wxpython.yml
+++ b/.github/workflows/build-app-wxpython.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   build:
     name: Build wxPython
-    runs-on: macos-13
+    runs-on: macos-15-intel
     timeout-minutes: 120
     permissions:
       contents: write

--- a/.github/workflows/validate-external.yml
+++ b/.github/workflows/validate-external.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   build:
     name: Validate
-    runs-on: macos-13
+    runs-on: macos-15-intel
     if: github.repository_owner != 'dortania'
 
     steps:


### PR DESCRIPTION
this is a needed update for CI/CD since legacy macos-13 are not available anymore.
Ronan
