### PR TITLE
Fixes bugs, adds support for Apple Silicon users to run the app itsel…

### DIFF
--- a/OpenCore-Patcher-GUI.spec
+++ b/OpenCore-Patcher-GUI.spec
@@ -4,29 +4,32 @@ import os
 import sys
 import time
 import subprocess
-
 from pathlib import Path
 
 from PyInstaller.building.api import PYZ, EXE, COLLECT
 from PyInstaller.building.osx import BUNDLE
 from PyInstaller.building.build_main import Analysis
 
-sys.path.append(os.path.abspath(os.getcwd()))
+# Fix: Dynamically find the absolute path of the directory containing this spec file
+SPEC_DIR = Path(__file__).parent.resolve()
+sys.path.append(str(SPEC_DIR))
 
 from opencore_legacy_patcher import constants
 
 block_cipher = None
 
+# Fix: Explicitly map the inputs using absolute paths to prevent CWD dependency issues
 datas = [
-   ('payloads.dmg', '.'),
-   ('Universal-Binaries.dmg', '.'),
+   (str(SPEC_DIR / 'payloads.dmg'), '.'),
+   (str(SPEC_DIR / 'Universal-Binaries.dmg'), '.'),
 ]
 
-if Path("DortaniaInternalResources.dmg").exists():
-   datas.append(('DortaniaInternalResources.dmg', '.'))
+# Fix: Evaluate the existence of the internal resources DMG relative to the spec file
+if (SPEC_DIR / "DortaniaInternalResources.dmg").exists():
+   datas.append((str(SPEC_DIR / 'DortaniaInternalResources.dmg'), '.'))
 
 
-a = Analysis(['OpenCore-Patcher-GUI.command'],
+a = Analysis([str(SPEC_DIR / 'OpenCore-Patcher-GUI.command')],
              pathex=[],
              binaries=[],
              datas=datas,
@@ -55,7 +58,7 @@ exe = EXE(pyz,
           upx=True,
           console=False,
           disable_windowed_traceback=False,
-          target_arch="x86_64",
+          target_arch="universal2",  # Fix: Allows the app to run natively on both Intel and Apple Silicon Macs
           codesign_identity=None,
           entitlements_file=None)
 
@@ -70,7 +73,7 @@ coll = COLLECT(exe,
 
 app = BUNDLE(coll,
              name='OpenCore-Patcher.app',
-             icon="payloads/Icon/AppIcons/OC-Patcher.icns",
+             icon=str(SPEC_DIR / "payloads/Icon/AppIcons/OC-Patcher.icns"), # Fix: Absolute path to the icon asset
              bundle_identifier="com.dortania.opencore-legacy-patcher",
              info_plist={
                 "CFBundleName": "OpenCore Legacy Patcher",


### PR DESCRIPTION
…f (not patch)

Updated paths to use absolute references for resources and changed target architecture to support both Intel and Apple Silicon Macs. And fix the following bugs:
1. Fixed Broken Relative Paths (CWD Bug) The Bug: Your original script used paths like 'payloads.dmg' or Path("DortaniaInternalResources.dmg").exists(). These paths only work if you run the pyinstaller command from the exact folder where those files live. If you ran it from a parent or subfolder, PyInstaller would fail to find the files, and it would silently skip adding the DortaniaInternalResources.dmg.

The Fix: The script now calculates SPEC_DIR = Path(__file__).parent.resolve(). Everything is built using absolute paths relative to where the .spec file actually sits, making the build completely location-independent.

2. Fixed App Icon Path Resolution The Bug: The path to the icon asset (payloads/Icon/AppIcons/OC-Patcher.icns) was hardcoded as a relative string. Depending on how PyInstaller initialized its bundling phase, it risked failing to bundle the .icns file correctly into the final macOS .app wrapper.

The Fix: Wrapped the icon path in str(SPEC_DIR / ...), ensuring the macOS compiler always finds the asset during compilation.

3. Fixed sys.path Appending for Imports The Bug: sys.path.append(os.path.abspath(os.getcwd())) looked for your opencore_legacy_patcher source files in the terminal's current working directory. If your automated build system or terminal was pointing elsewhere, the script would crash immediately with a ModuleNotFoundError: No module named 'opencore_legacy_patcher'.

The Fix: Changed to sys.path.append(str(SPEC_DIR)), ensuring your internal project constants can always be imported safely.

4. Optimized Architecture Targeting The Bug: The configuration had target_arch="x86_64". While not strictly a script-crashing bug, it forced the OpenCore Legacy Patcher GUI to compile only for Intel processors. If run on an Apple Silicon Mac (M1/M2/M3), macOS would be forced to launch the app via Rosetta 2 translation.

The Fix: Upgraded target_arch to "universal2". If you are building on a modern Mac with universal dependencies, this generates a native hybrid slice that runs optimally on both Intel and Apple Silicon machines.