### PR TITLE
Zu mein API wechseln, um macOS 26 Tahoe-Unterstützung auf nicht-T2 Ma…

### DIFF
--- a/opencore_legacy_patcher/support/metallib_handler.py
+++ b/opencore_legacy_patcher/support/metallib_handler.py
@@ -17,7 +17,7 @@ from ..datasets import os_data
 
 
 METALLIB_INSTALL_PATH: str  = "/Library/Application Support/Dortania/MetallibSupportPkg"
-METALLIB_API_LINK:     str  = "https://dortania.github.io/MetallibSupportPkg/manifest.json"
+METALLIB_API_LINK:     str  = "https://albert-mueller.github.io/MetallibSupportPkg/manifest.json"
 
 METALLIB_ASSET_LIST:   list = None
 


### PR DESCRIPTION
…cs verbessern

Zu mein API wechseln, um macOS 26 Tahoe-Unterstützung auf nicht-T2 Macs verbessern Warnung: das ist effektiv nur für der Metallibs-API. Für den KDK, ich fahre fort, Dortanias KDK zu verwenden.