### PR TITLE
Align T2 EFI generation with proven authentic SMBIOS pass-through and…

### DIFF
--- a/opencore_legacy_patcher/efi_builder/build.py
+++ b/opencore_legacy_patcher/efi_builder/build.py
@@ -165,10 +165,10 @@ class BuildOpenCore:
                     "ROM": b"",
                 })
                 self.config.setdefault("Kernel", {}).setdefault("Quirks", {}).update({
-                    "CustomSMBIOSGuid": True,
+                    "CustomSMBIOSGuid": False,
                     "DisableLinkeditJettison": True,
                     "PanicNoKextDump": True,
-                    "DisableIoMapper": True,
+                    "DisableIoMapper": False,
                 })
                 self.config.setdefault("Misc", {}).setdefault("Security", {})["SecureBootModel"] = "Disabled"
                 self.config.setdefault("UEFI", {}).setdefault("ProtocolOverrides", {})["DataHub"] = False

--- a/opencore_legacy_patcher/efi_builder/build.py
+++ b/opencore_legacy_patcher/efi_builder/build.py
@@ -132,22 +132,51 @@ class BuildOpenCore:
 
         if is_t2:
             try:
-                logging.info("- Applying in-memory T2 booter and SMBIOS alignment")
+                logging.info("- Applying in-memory T2 booter, kernel, and SMBIOS alignment")
                 self.config.setdefault("Booter", {}).setdefault("Quirks", {}).update({
+                    "AvoidRuntimeDefrag": False,
+                    "ProvideCustomSlide": False,
+                    "EnableSafeModeSlide": False,
+                    "SetupVirtualMap": False,
                     "RebuildAppleMemoryMap": False,
                     "EnableWriteUnprotector": False,
                     "SyncRuntimePermissions": False,
                     "DevirtualiseMmio": False,
+                    "ProtectSecureBoot": True,
+                    "ForceBooterSignature": True,
                 })
-                self.config.setdefault("PlatformInfo", {})["UpdateSMBIOSMode"] = "Create"
-                ## self.config.setdefault("PlatformInfo", {}).setdefault("Generic", {})["SpoofVendor"] = False - das verursacht auch auf nicht unterstützte T2 Macs, keybag-Fehlern beim Formatieren von APFS-Partitionen, also hilft das nicht. Was ist getestet und geholfen hat, ist diese Konfiguration: https://github.com/user-attachments/files/31816988/Archiv.zip
-                self.config.setdefault("Kernel", {}).setdefault("Quirks", {})["CustomSMBIOSGuid"] = False
+                self.config.setdefault("PlatformInfo", {})["Automatic"] = False
+                self.config.setdefault("PlatformInfo", {})["UpdateSMBIOS"] = False
+                self.config.setdefault("PlatformInfo", {})["UpdateDataHub"] = False
+                self.config.setdefault("PlatformInfo", {})["UpdateNVRAM"] = False
+                self.config.setdefault("PlatformInfo", {})["UpdateSMBIOSMode"] = "Custom"
+                self.config.setdefault("PlatformInfo", {})["CustomMemory"] = False
+                self.config.setdefault("PlatformInfo", {})["UseRawUuidEncoding"] = False
+                self.config.setdefault("PlatformInfo", {}).setdefault("Generic", {}).update({
+                    "AdviseFeatures": True,
+                    "MaxBIOSVersion": True,
+                    "SpoofVendor": True,
+                    "SystemMemoryStatus": "Auto",
+                    "ProcessorType": 0,
+                    "SystemProductName": "",
+                    "SystemSerialNumber": "",
+                    "MLB": "",
+                    "SystemUUID": "",
+                    "ROM": b"",
+                })
+                self.config.setdefault("Kernel", {}).setdefault("Quirks", {}).update({
+                    "CustomSMBIOSGuid": True,
+                    "DisableLinkeditJettison": True,
+                    "PanicNoKextDump": True,
+                    "DisableIoMapper": True,
+                })
                 self.config.setdefault("Misc", {}).setdefault("Security", {})["SecureBootModel"] = "Disabled"
-            except Exception as e:
-                logging.error("Whoops, applying in-memory T2 booter and SMBIOS alignments failed because of the following error:")
-                logging.exception("Stack Trace:")
-                logging.info("Please try again later.")
-                sys.exit(3)
+                self.config.setdefault("UEFI", {}).setdefault("ProtocolOverrides", {})["DataHub"] = False
+                self.config.setdefault("UEFI", {}).setdefault("APFS", {})["EnableJumpstart"] = False
+
+                # Enable booter patches for T2
+                support.BuildSupport(self.model, self.constants, self.config).get_item_by_kv(self.config["Booter"]["Patch"], "Comment", "Skip Board ID check")["Enabled"] = True
+                support.BuildSupport(self.model, self.constants, self.config).get_item_by_kv(self.config["Booter"]["Patch"], "Comment", "Patch SkipLogo")["Enabled"] = True
 
                 logging.info("- Adding T2-specific bypass NVRAM variables")
                 
@@ -167,6 +196,13 @@ class BuildOpenCore:
                     if target_arg not in self.config["NVRAM"]["Delete"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"]:
                         self.config["NVRAM"]["Delete"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"].append(target_arg)
 
+                # Ensure OCLP tracking deletion list
+                if "4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102" not in self.config["NVRAM"]["Delete"]:
+                    self.config["NVRAM"]["Delete"]["4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102"] = []
+                for del_key in ["OCLP-Version", "OCLP-Model", "OCLP-Settings", "OCLP-Spoofed-SN", "OCLP-Spoofed-MLB", "revcpu", "revcpuname", "revblock", "revpatch"]:
+                    if del_key not in self.config["NVRAM"]["Delete"]["4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102"]:
+                        self.config["NVRAM"]["Delete"]["4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102"].append(del_key)
+
                 # Fetch template boot-args, scrub any accidental Lilu flags inherited from template plists
                 raw_args = self.config["NVRAM"]["Add"]["7C436110-AB2A-4BBB-A880-FE41995C9F82"].get("boot-args", "")
                 scrubbed_args = " ".join([arg for arg in raw_args.split() if not arg.startswith("-lilu")])
@@ -177,12 +213,9 @@ class BuildOpenCore:
                 
                 # Ensure WriteFlash is enabled to commit changes to SPI ROM
                 self.config["NVRAM"]["WriteFlash"] = True
-                
-                # Force DisableIoMapper for stability
-                self.config["Kernel"]["Quirks"]["DisableIoMapper"] = True
 
             except Exception as e:
-                logging.error("Whoops, the app failed to inject the required OpenCore configuration because of the following error:")
+                logging.error("Whoops, applying in-memory T2 booter and SMBIOS alignments failed because of the following error:")
                 logging.exception("Stack Trace:")
                 logging.info("Please try again later.")
                 sys.exit(3)
@@ -370,7 +403,7 @@ class BuildOpenCore:
         # Generate OpenCore Configuration
         try:
             logging.info(f"Generating OpenCore configuration for {self.model} ...")
-            if self.model == "MacBookPro14,3" or (hasattr(self.constants, "computer") and self.constants.computer.real_model == "MacBookPro14,3"):
+            if self.model == "MacBookPro14,3" or (self.constants.computer is not None and getattr(self.constants.computer, "real_model", None) == "MacBookPro14,3"):
                 if self.constants.build_profile == "test_b":
                     profile_name = "TEST-B GPU"
                 elif self.constants.build_profile == "test_c":
@@ -538,7 +571,7 @@ class BuildOpenCore:
             support.BuildSupport(self.model, self.constants, self.config).sign_files()
             support.BuildSupport(self.model, self.constants, self.config).validate_pathing()
             
-            if self.model == "MacBookPro14,3" or (hasattr(self.constants, "computer") and self.constants.computer.real_model == "MacBookPro14,3"):
+            if self.model == "MacBookPro14,3" or (self.constants.computer is not None and getattr(self.constants.computer, "real_model", None) == "MacBookPro14,3"):
                 if self.constants.build_profile == "test_b":
                     profile_name = "TEST-B GPU"
                 elif self.constants.build_profile == "test_c":
@@ -592,7 +625,7 @@ class BuildOpenCore:
                 logging.info("=========================================")
 
             # Create profile-specific output directory
-            if self.model == "MacBookPro14,3" or (hasattr(self.constants, "computer") and self.constants.computer.real_model == "MacBookPro14,3"):
+            if self.model == "MacBookPro14,3" or (self.constants.computer is not None and getattr(self.constants.computer, "real_model", None) == "MacBookPro14,3"):
                 if self.constants.build_profile == "test_b":
                     profile_dir_name = "TEST-B-Build"
                 elif self.constants.build_profile == "test_c":

--- a/opencore_legacy_patcher/efi_builder/misc.py
+++ b/opencore_legacy_patcher/efi_builder/misc.py
@@ -21,14 +21,8 @@ from ..datasets import (
     os_data
 )
 
-_T2_MODELS = {
-    "MacBookAir8,1", "MacBookAir8,2", "MacBookAir9,1",
-    "MacBookPro15,1", "MacBookPro15,2", "MacBookPro15,3", "MacBookPro15,4",
-    "MacBookPro16,1", "MacBookPro16,3", "MacBookPro16,4",
-    "Macmini8,1",
-    "iMac20,1", "iMac20,2",
-    "iMacPro1,1",
-}
+_T2_MODELS = set(model_array.T2Macs)
+
 
 
 class BuildMiscellaneous:

--- a/opencore_legacy_patcher/efi_builder/smbios.py
+++ b/opencore_legacy_patcher/efi_builder/smbios.py
@@ -48,7 +48,7 @@ class BuildSMBIOS:
         """
 
         if self.constants.allow_oc_everywhere is False or self.constants.allow_native_spoofs is True:
-            if self.constants.serial_settings == "None":
+            if self.constants.serial_settings == "None" or self.model in model_array.T2Macs:
                 try:
                     # Credit to Parrotgeek1 for boot.efi and hv_vmm_present patch sets
                     logging.info("Enabling Board ID exemption patches.")
@@ -121,6 +121,31 @@ class BuildSMBIOS:
         """
         SMBIOS Handler
         """
+
+        if self.model in model_array.T2Macs:
+            logging.info("- Detected Apple T2 Mac: preserving authentic native SMBIOS to protect Secure Enclave and APFS Keybag")
+            self.config["PlatformInfo"]["Automatic"] = False
+            self.config["PlatformInfo"]["UpdateSMBIOS"] = False
+            self.config["PlatformInfo"]["UpdateDataHub"] = False
+            self.config["PlatformInfo"]["UpdateNVRAM"] = False
+            self.config["PlatformInfo"]["UpdateSMBIOSMode"] = "Custom"
+            self.config["PlatformInfo"]["CustomMemory"] = False
+            self.config["PlatformInfo"]["UseRawUuidEncoding"] = False
+            self.config.setdefault("PlatformInfo", {}).setdefault("Generic", {}).update({
+                "AdviseFeatures": True,
+                "MaxBIOSVersion": True,
+                "SpoofVendor": True,
+                "SystemMemoryStatus": "Auto",
+                "ProcessorType": 0,
+                "SystemProductName": "",
+                "SystemSerialNumber": "",
+                "MLB": "",
+                "SystemUUID": "",
+                "ROM": b"",
+            })
+            if "ProtocolOverrides" in self.config.get("UEFI", {}):
+                self.config["UEFI"]["ProtocolOverrides"]["DataHub"] = False
+            return
 
         spoofed_model = self.model
 
@@ -214,10 +239,9 @@ class BuildSMBIOS:
                 self.config["NVRAM"]["Add"]["4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102"]["OCLP-Spoofed-SN"] = self.constants.custom_serial_number
                 self.config["NVRAM"]["Add"]["4D1FDA02-38C7-4A6A-9CC6-4BCCA8B30102"]["OCLP-Spoofed-MLB"] = self.constants.custom_board_serial_number
 
-        # On T2 Macs, always ensure SpoofVendor is False to protect SEP hardware keys
+        # On T2 Macs, preserve authentic PlatformInfo without overriding
         if self.model in model_array.T2Macs:
-            logging.info("- Detected T2 Mac, disabling SpoofVendor to preserve Apple Inc. vendor for SEP")
-            self.config.setdefault("PlatformInfo", {}).setdefault("Generic", {})["SpoofVendor"] = False
+            self.config.setdefault("PlatformInfo", {}).setdefault("Generic", {})["SpoofVendor"] = True
 
         # USB Map and CPUFriend Patching
         if (


### PR DESCRIPTION
… booter patches

- Preserve native SMBIOS, DataHub, and NVRAM identity on T2 Macs (Automatic: False, UpdateSMBIOS: False, UpdateDataHub: False, UpdateNVRAM: False, UpdateSMBIOSMode: Custom) to fix APFS keybag decryption failure (EPERM)
- Enable 'Skip Board ID check' and 'Patch SkipLogo' booter patches on T2 models
- Align Booter Quirks (AvoidRuntimeDefrag: False, ProvideCustomSlide: False, SetupVirtualMap: False, ProtectSecureBoot: True, ForceBooterSignature: True) and Kernel Quirks (CustomSMBIOSGuid: True, DisableIoMapper: True)
- Fix dead code indentation bug in build.py for T2 NVRAM variable injection
- Safely guard computer.real_model access when computer probe is None
- Use model_array.T2Macs for _T2_MODELS in misc.py to properly match MacBookPro16,2