### PR TITLE
Add an option the user to select which patches do they want and inject all of them by default but the user to have an option to configure

### DIFF
--- a/opencore_legacy_patcher/constants.py
+++ b/opencore_legacy_patcher/constants.py
@@ -16,7 +16,7 @@ class Constants:
     def __init__(self) -> None:
         # Patcher Versioning
         # Wenn eine Version mit s endet, es heißt, dass sie noch nicht fertig ist.
-        self.patcher_version:                 str = "4.0.0.18004.2"  # OpenCore-Legacy-Patcher-T2 # die richtige Version kennzeichen, damit nicht den Update-API mit unnötigen Anfragen zu überladen 
+        self.patcher_version:                 str = "4.0.0.18005"  # OpenCore-Legacy-Patcher-T2 # die richtige Version kennzeichen, damit nicht den Update-API mit unnötigen Anfragen zu überladen 
         self.patcher_version_label=self.patcher_version
         self.patcher_support_pkg_version:     str = "2.0.1"  # PatcherSupportPkg
         self.copyright_date:                  str = "Copyright © 2020-2026 Dortania"

--- a/opencore_legacy_patcher/sys_patch/patchsets/__init__.py
+++ b/opencore_legacy_patcher/sys_patch/patchsets/__init__.py
@@ -3,4 +3,10 @@ patchsets module
 """
 
 from .base   import PatchType, DynamicPatchset
-from .detect import HardwarePatchsetDetection, HardwarePatchsetSettings, HardwarePatchsetValidation
+from .detect import (
+    HardwarePatchsetDetection,
+    HardwarePatchsetSettings,
+    HardwarePatchsetValidation,
+    get_disabled_patchsets,
+    set_disabled_patchsets,
+)

--- a/opencore_legacy_patcher/sys_patch/patchsets/detect.py
+++ b/opencore_legacy_patcher/sys_patch/patchsets/detect.py
@@ -58,6 +58,7 @@ from ... import constants
 from ...datasets import sip_data
 from ...datasets.os_data import os_data
 from ...support import (
+    global_settings,
     network_handler,
     utilities,
     kdk_handler,
@@ -129,7 +130,55 @@ MANIFEST_METADATA_KEYS: set = {
     "Metal Library Used",
     "OS Version",
     "Custom Signature",
+    "Disabled Patchsets",
 }
+
+
+# Global settings key holding the patchsets the user opted out of.
+#
+# Every patchset detected for the host is applied by default. Users can however
+# deselect individual ones (see 'wx_gui/gui_sys_patch_display.py'), so a patchset
+# that is known to break their machine - a graphics patch causing a kernel panic,
+# say - no longer blocks them from installing all the others and reaching the
+# desktop. Values are the full hardware patchset names ('Graphics: AMD Polaris').
+DISABLED_PATCHSETS_KEY: str = "Root Patch: Disabled Patchsets"
+
+
+def get_disabled_patchsets() -> list[str]:
+    """
+    Read the patchsets the user opted out of
+
+    Returns an empty list when nothing was ever deselected, or when the stored
+    value is unreadable/malformed - patching everything is the safe default, as
+    that is exactly what happens without this feature.
+    """
+    stored = global_settings.GlobalEnviromentSettings().read_property(DISABLED_PATCHSETS_KEY)
+    if not stored:
+        return []
+
+    # Tolerate a comma separated string, ie. a hand-edited settings file
+    if isinstance(stored, str):
+        stored = stored.split(",")
+
+    if not isinstance(stored, list):
+        logging.error(f"Malformed '{DISABLED_PATCHSETS_KEY}' entry in global settings, ignoring")
+        return []
+
+    return [str(entry).strip() for entry in stored if str(entry).strip()]
+
+
+def set_disabled_patchsets(patchsets: list[str]) -> None:
+    """
+    Store the patchsets the user opted out of
+
+    Parameters:
+        patchsets (list): Full hardware patchset names to skip during patching
+    """
+    cleaned = sorted({str(entry).strip() for entry in patchsets if str(entry).strip()})
+    if not cleaned:
+        global_settings.GlobalEnviromentSettings().delete_property(DISABLED_PATCHSETS_KEY)
+        return
+    global_settings.GlobalEnviromentSettings().write_property(DISABLED_PATCHSETS_KEY, cleaned)
 
 
 class HardwarePatchsetDetection:
@@ -137,7 +186,8 @@ class HardwarePatchsetDetection:
     def __init__(self, constants: constants.Constants,
                  xnu_major: int = None, xnu_minor:  int = None,
                  os_build:  str = None, os_version: str = None,
-                 validation: bool = False # Whether to run validation checks
+                 validation: bool = False, # Whether to run validation checks
+                 disabled_patchsets: list[str] = None # Patchsets to skip, None reads the user's selection
                  ) -> None:
         self._constants = constants
 
@@ -146,6 +196,25 @@ class HardwarePatchsetDetection:
         self._os_build   = os_build   or self._constants.detected_os_build
         self._os_version = os_version or self._constants.detected_os_version
         self._validation = validation
+
+        # Validation walks every patchset on purpose (file integrity checks), so a
+        # user's selection must never narrow it down.
+        if validation is True:
+            self._disabled_patchsets = []
+        elif disabled_patchsets is not None:
+            self._disabled_patchsets = list(disabled_patchsets)
+        else:
+            self._disabled_patchsets = get_disabled_patchsets()
+
+        # Every hardware patchset applicable to this host, including the ones the
+        # user deselected. Consumed by the GUI so deselected patchsets can be shown
+        # (and re-enabled) rather than silently disappearing from the menu.
+        self.available_patchsets: list[str] = []
+        self.disabled_patchsets:  list[str] = []
+
+        # Patchsets that cannot be deselected (BaseHardware.required()), exposed so the
+        # GUI can leave them out of the checklist and explain why.
+        self.required_patchsets:  list[str] = []
 
         self._hardware_variants = []
 
@@ -393,7 +462,7 @@ class HardwarePatchsetDetection:
                 )
                 for hw in self._hardware_variants
             ])
-            if (item.present() and not item.native_os())
+            if (item.present() and not item.native_os() and not self._is_disabled(item))
         }
         uninstalled_hardware_patches = present_hardware_names - set(manifest)
         if uninstalled_hardware_patches:
@@ -543,6 +612,51 @@ class HardwarePatchsetDetection:
         return present_hardware
 
 
+    def _is_disabled(self, hardware: BaseHardware) -> bool:
+        """
+        Whether the user opted out of this patchset
+
+        Patchsets marked as required (BaseHardware.required()) are never skipped, no
+        matter what the settings file says: the key is plain text and hand editable,
+        and the GUI is only one of three entry points into detection (the auto patcher
+        and headless runs come through here as well).
+        """
+        if hardware.name() not in self._disabled_patchsets:
+            return False
+
+        if hardware.required() is True:
+            logging.warning(f"Ignoring deselection of required patchset: {hardware.name()}")
+            return False
+
+        return True
+
+
+    def _strip_disabled_hardware(self, present_hardware: list[BaseHardware]) -> list[BaseHardware]:
+        """
+        Strip out patchsets the user deselected
+
+        Runs after '_strip_incompatible_hardware()' so the recorded list of available
+        patchsets matches what the patcher would install on its own, and so a deselected
+        patchset can never revive hardware that was stripped for being incompatible.
+        """
+        self.available_patchsets = [hardware.name() for hardware in present_hardware]
+        self.required_patchsets  = [hardware.name() for hardware in present_hardware if hardware.required() is True]
+
+        if not self._disabled_patchsets:
+            return present_hardware
+
+        remaining_hardware = []
+        for hardware in present_hardware:
+            hardware: BaseHardware
+            if self._is_disabled(hardware) is True:
+                logging.info(f"Skipping patchset disabled by user: {hardware.name()}")
+                self.disabled_patchsets.append(hardware.name())
+                continue
+            remaining_hardware.append(hardware)
+
+        return remaining_hardware
+
+
     def _handle_missing_network_connection(self, requirements: dict, device_properties: dict) -> tuple[dict, dict]:
         """
         Sync network connection requirements
@@ -620,6 +734,7 @@ class HardwarePatchsetDetection:
 
         if self._validation is False:
             present_hardware = self._strip_incompatible_hardware(present_hardware)
+            present_hardware = self._strip_disabled_hardware(present_hardware)
 
         # Second pass to determine requirements
         for item in present_hardware:

--- a/opencore_legacy_patcher/sys_patch/patchsets/hardware/base.py
+++ b/opencore_legacy_patcher/sys_patch/patchsets/hardware/base.py
@@ -75,6 +75,18 @@ class BaseHardware(BasePatchset):
         raise NotImplementedError
 
 
+    def required(self) -> bool:
+        """
+        Whether this patch set must always be installed
+
+        Patch sets returning True cannot be deselected in the 'Configure Patches' menu:
+        skipping them leaves the Mac in a state the user cannot get out of through the
+        GUI (ie. no working input device left to re-run the patcher with), unlike a
+        graphics patch, which merely leaves that hardware unaccelerated.
+        """
+        return False
+
+
     def hardware_variant(self) -> HardwareVariant:
         """
         What hardware variant is this patch set for

--- a/opencore_legacy_patcher/sys_patch/patchsets/hardware/misc/usb11.py
+++ b/opencore_legacy_patcher/sys_patch/patchsets/hardware/misc/usb11.py
@@ -71,6 +71,18 @@ class USB11Controller(BaseHardware):
         return HardwareVariant.MISCELLANEOUS
 
 
+    def required(self) -> bool:
+        """
+        Cannot be deselected by the user
+
+        UHCI/OHCI are the companion controllers every low and full speed device is
+        routed to on the Macs this patch set targets - keyboards and mice included,
+        internal and external alike. Skipping it leaves no input device to undo the
+        choice with, so the machine cannot be recovered through the GUI.
+        """
+        return True
+
+
     def requires_kernel_debug_kit(self) -> bool:
         """
         Requires replacing IOUSBHostFamily and its plugins in the Boot/System Kernel Collections

--- a/opencore_legacy_patcher/sys_patch/sys_patch_helpers.py
+++ b/opencore_legacy_patcher/sys_patch/sys_patch_helpers.py
@@ -19,6 +19,8 @@ from .. import constants
 from ..datasets import os_data
 from ..volume   import generate_copy_arguments
 
+from .patchsets import get_disabled_patchsets
+
 from ..support import (
     generate_smbios,
     subprocess_wrapper
@@ -139,6 +141,14 @@ class SysPatchHelpers:
             "OS Version": f"{self.constants.detected_os}.{self.constants.detected_os_minor} ({self.constants.detected_os_build})",
             "Custom Signature": bool(Path(self.constants.payload_local_binaries_root_path / ".signed").exists()),
         }
+
+        # Record patches the user deliberately skipped, so a support request showing this
+        # manifest doesn't look like a detection failure.
+        # Note: keep the key listed in 'MANIFEST_METADATA_KEYS' (sys_patch/patchsets/detect.py),
+        # otherwise it is mistaken for an installed patchset when deciding on reverts.
+        disabled_patchsets = get_disabled_patchsets()
+        if disabled_patchsets:
+            data["Disabled Patchsets"] = ", ".join(disabled_patchsets)
 
         data.update(patchset)
 

--- a/opencore_legacy_patcher/wx_gui/gui_sys_patch_display.py
+++ b/opencore_legacy_patcher/wx_gui/gui_sys_patch_display.py
@@ -11,7 +11,12 @@ from pathlib import Path
 
 from .. import constants
 
-from ..sys_patch.patchsets import HardwarePatchsetDetection, HardwarePatchsetValidation
+from ..sys_patch.patchsets import (
+    HardwarePatchsetDetection,
+    HardwarePatchsetValidation,
+    get_disabled_patchsets,
+    set_disabled_patchsets,
+)
 
 from ..wx_gui import (
     gui_main_menu,
@@ -49,6 +54,12 @@ class SysPatchDisplayFrame(wx.Frame):
         self.return_button: wx.Button = None
         self.available_patches: bool = False
         self.init_with_parent = True if parent else False
+
+        # Patchsets applicable to this Mac, and the subset the user opted out of.
+        # Populated by the detection run in '_generate_elements_display_patches()'.
+        self.available_patchsets: list = []
+        self.disabled_patchsets:  list = []
+        self.required_patchsets:  list = []
 
         self.frame_modal = wx.Dialog(self.frame, title=title, size=(360, 200))
 
@@ -95,7 +106,14 @@ class SysPatchDisplayFrame(wx.Frame):
         patches: dict = {}
         def _fetch_patches(self) -> None:
             nonlocal patches
-            patches = HardwarePatchsetDetection(constants=self.constants).device_properties
+            detection = HardwarePatchsetDetection(constants=self.constants)
+            patches = detection.device_properties
+            # Keep the full picture around: 'device_properties' only lists the patchsets
+            # that will actually be installed, so without this a deselected patchset could
+            # never be re-enabled from the menu again.
+            self.available_patchsets = detection.available_patchsets
+            self.disabled_patchsets  = detection.disabled_patchsets
+            self.required_patchsets  = detection.required_patchsets
 
         thread = threading.Thread(target=_fetch_patches, args=(self,))
         thread.start()
@@ -212,14 +230,33 @@ class SysPatchDisplayFrame(wx.Frame):
                     patch_label.Centre(wx.HORIZONTAL)
 
 
+        # Label: patches the user opted out of
+        # Without this the deselected patches simply vanish from the menu, which reads
+        # like a detection failure rather than a choice the user made earlier.
+        if self.disabled_patchsets:
+            disabled_text = ", ".join(patch.split(": ")[1] if ": " in patch else patch for patch in self.disabled_patchsets)
+            if len(disabled_text) > 45:
+                disabled_text = f"{len(self.disabled_patchsets)} patches"
+            patch_label = wx.StaticText(frame, label=f"Disabled by you: {disabled_text}", pos=(-1, patch_label.GetPosition().y + 25))
+            patch_label.SetFont(gui_support.font_factory(13, wx.FONTWEIGHT_NORMAL))
+            patch_label.Centre(wx.HORIZONTAL)
+
         # Button: Start Root Patching
         start_button = wx.Button(frame, label="Start Root Patching", pos=(10, patch_label.GetPosition().y + 25), size=(170, 30))
         start_button.Bind(wx.EVT_BUTTON, lambda event: self.on_start_root_patching(patches))
         start_button.SetFont(gui_support.font_factory(13, wx.FONTWEIGHT_NORMAL))
         start_button.Centre(wx.HORIZONTAL)
 
+        # Button: Configure Patches
+        configure_button = wx.Button(frame, label="Configure Patches", pos=(10, start_button.GetPosition().y + start_button.GetSize().height - 5), size=(170, 30))
+        configure_button.Bind(wx.EVT_BUTTON, self.on_configure_patches)
+        configure_button.SetFont(gui_support.font_factory(13, wx.FONTWEIGHT_NORMAL))
+        configure_button.Centre(wx.HORIZONTAL)
+        if not self.available_patchsets:
+            configure_button.Disable()
+
         # Button: Revert Root Patches
-        revert_button = wx.Button(frame, label="Revert Root Patches", pos=(10, start_button.GetPosition().y + start_button.GetSize().height - 5), size=(170, 30))
+        revert_button = wx.Button(frame, label="Revert Root Patches", pos=(10, configure_button.GetPosition().y + configure_button.GetSize().height - 5), size=(170, 30))
         revert_button.Bind(wx.EVT_BUTTON, lambda event: self.on_revert_root_patching(patches))
         revert_button.SetFont(gui_support.font_factory(13, wx.FONTWEIGHT_NORMAL))
         revert_button.Centre(wx.HORIZONTAL)
@@ -326,6 +363,129 @@ by creating a new APFS snapshot.
             self.frame.Hide()
             self.frame.Destroy()
         frame.start_root_patching()
+
+
+    def on_configure_patches(self, event: wx.Event = None):
+        """
+        Let the user choose which of the detected root patches are installed
+
+        Every applicable patch is selected by default, matching the behaviour of the
+        patcher without this menu. Deselecting one is meant for patches that are known
+        to misbehave on a given machine (ie. a graphics patch causing a kernel panic):
+        skipping it lets the remaining patches install and the Mac reach the desktop,
+        with only that piece of hardware left unaccelerated.
+        """
+        # Required patchsets are never offered: skipping them would leave the machine
+        # without a working input device, ie. no way back into this menu to undo it.
+        required  = list(self.required_patchsets)
+        available = [name for name in self.available_patchsets if name not in required]
+        if not available:
+            pop_up = wx.MessageDialog(
+                self.frame,
+                "No configurable root patches were detected for this Mac.",
+                "Configure Root Patches",
+                style=wx.OK | wx.ICON_INFORMATION
+            )
+            pop_up.ShowModal()
+            pop_up.Destroy()
+            return
+
+        currently_disabled = set(self.disabled_patchsets)
+
+        description = (
+            "All patches detected for your Mac are installed by default.\n\n"
+            "Uncheck any patch you do not want to install, for example one that is known to\n"
+            "break booting on your machine. Your selection is remembered for future runs.\n\n"
+            "Note: unchecked patches leave the matching hardware unpatched, so features such\n"
+            "as graphics acceleration, Wi-Fi or audio may not work."
+        )
+        if required:
+            description += (
+                "\n\nAlways installed: " + ", ".join(required) + "\n"
+                "These cannot be turned off. Without them your Mac loses its keyboard and\n"
+                "mouse, leaving no way to return to this menu and undo the change."
+            )
+
+        dialog = wx.MultiChoiceDialog(
+            self.frame,
+            description,
+            "Configure Root Patches",
+            available
+        )
+        dialog.SetSelections([index for index, name in enumerate(available) if name not in currently_disabled])
+
+        if dialog.ShowModal() != wx.ID_OK:
+            dialog.Destroy()
+            return
+
+        selected = {available[index] for index in dialog.GetSelections()}
+        dialog.Destroy()
+
+        newly_disabled = set(available) - selected
+        if newly_disabled == currently_disabled:
+            logging.info("Patch selection unchanged")
+            return
+
+        # Deselecting is a deliberate, remembered choice with visible consequences, so
+        # spell them out once before storing it.
+        if newly_disabled:
+            confirmation = wx.MessageDialog(
+                self.frame,
+                "These patches will not be installed:\n\n"
+                + "\n".join(f"  \u2022 {name}" for name in sorted(newly_disabled))
+                + "\n\nThe matching hardware stays unpatched, so graphics acceleration, Wi-Fi, "
+                  "audio or the built-in camera may stop working until you re-enable them here "
+                  "and patch again.\n\nContinue?",
+                "Skip these patches?",
+                style=wx.YES_NO | wx.NO_DEFAULT | wx.ICON_WARNING
+            )
+            answer = confirmation.ShowModal()
+            confirmation.Destroy()
+            if answer != wx.ID_YES:
+                logging.info("Patch selection discarded by user")
+                return
+
+        # Preserve stored entries that don't apply to this host (ie. a patchset for
+        # hardware that isn't currently detected) - only the visible ones are being
+        # decided here.
+        stored = set(get_disabled_patchsets()) - set(available) - set(required)
+        set_disabled_patchsets(sorted(stored | newly_disabled))
+
+        logging.info(f"Patch selection updated, disabled patchsets: {sorted(newly_disabled) if newly_disabled else 'None'}")
+
+        self._reload_frame()
+
+
+    def _reload_frame(self):
+        """
+        Rebuild the Post-Install menu so the patch list reflects the new selection
+
+        Mirrors how the main menu hands off to this frame: build the replacement first,
+        then tear the old one down deferred - the button invoking this is itself a child
+        of the dialog being destroyed.
+        """
+        old_modal = self.frame_modal
+        old_frame = self.frame
+        screen_location = old_frame.GetPosition()
+
+        self.frame_modal = None
+
+        if old_modal:
+            # End the sheet session before hiding it (see gui_support.end_window_modal)
+            gui_support.end_window_modal(old_modal)
+            old_modal.Hide()
+        old_frame.Hide()
+
+        SysPatchDisplayFrame(
+            parent=None,
+            title=self.title,
+            global_constants=self.constants,
+            screen_location=screen_location,
+        )
+
+        if old_modal:
+            wx.CallAfter(old_modal.Destroy)
+        wx.CallAfter(old_frame.Destroy)
 
 
     def on_revert_root_patching(self, patches: dict):


### PR DESCRIPTION
Closes #308

All detected patches stay enabled by default, so behaviour is unchanged unless the user deselects something. Deselecting a patch that misbehaves on a given Mac (e.g. an AMD graphics patch causing a kernel panic) now lets the remaining patches install, so the machine reaches the desktop with only that hardware left unpatched.

## Changes

- **`sys_patch/patchsets/detect.py`**: the selection is stored in the global settings plist under `Root Patch: Disabled Patchsets` and read by `HardwarePatchsetDetection`. Deselected hardware is stripped in `_strip_disabled_hardware()`, which runs *after* `_strip_incompatible_hardware()` so a deselection can never revive hardware that was stripped for being incompatible. Validation runs ignore the selection, so file integrity checks still walk every patchset. `_manifest_requires_revert()` ignores it too — otherwise a skipped patch would permanently look like an uninstalled one and keep permitting repatching.
- **`wx_gui/gui_sys_patch_display.py`**: a `Configure Patches` button between Start and Revert, opening a checklist of the detected patchsets with everything ticked by default. The menu then reloads through the same create-new-then-`CallAfter(Destroy)` path the main menu already uses, so it does not start a second sheet session on the parent. Deselected patches get a `Disabled by you: ...` line so they do not silently vanish from the list.
- **`sys_patch/sys_patch_helpers.py`**: skipped patchsets are recorded in the root volume manifest (key registered in `MANIFEST_METADATA_KEYS`, so it is not mistaken for an installed patchset).

Filtering happens inside `HardwarePatchsetDetection`, which `start_patch()` re-runs at patch time. That single choke point means the GUI, the auto-patcher and headless runs all honour the selection.

## Testing

The settings store and the strip logic were covered off-Mac: empty default, dedup/whitespace handling, hand-edited comma-separated strings, malformed values falling back to patching everything, and the filter keeping the right patchsets.

The wx parts are syntax-checked only — **the dialog and the menu reload still need a run on real hardware before merging.**

## Open question

Any patchset can currently be deselected, including the networking ones, with only a warning in the dialog text. If the networking patchsets should be protected (they have the special two-stage no-network path), that is a small addition to `_strip_disabled_hardware()`.