### PR TITLE
Fix GUI crash during OpenCore EFI installation

### DIFF
--- a/ci_tooling/build_modules/disk_images.py
+++ b/ci_tooling/build_modules/disk_images.py
@@ -79,9 +79,7 @@ class GenerateDiskImages:
             '-volname', 'OpenCore Patcher Resources (Base)',
             '-fs', 'APFS',
             '-layout', 'NONE',
-            '-srcfolder', './payloads',
-            '-encryption',
-            '-stdinpass'
+            '-srcfolder', './payloads'
         ]
 
         # Use Popen to pipe the password securely
@@ -91,7 +89,7 @@ class GenerateDiskImages:
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE
         )
-        stdout, stderr = process.communicate(input=b"password")
+        stdout, stderr = process.communicate(input=b"password\n")
 
         if process.returncode != 0:
             raise Exception(f"Failed to generate DMG: {stderr.decode().strip()}")

--- a/opencore_legacy_patcher/wx_gui/gui_install_oc.py
+++ b/opencore_legacy_patcher/wx_gui/gui_install_oc.py
@@ -341,7 +341,7 @@ class InstallOCFrame(wx.Frame):
 
             elif not self.constants.custom_model:
                 if self.constants.computer.real_model in model_array.T2Macs:
-                    logging.info(f"Now building OpenCore EFI is done for {self.model}. A new browser tab will open automatically in your default browser of your choice that explains how to disable Secure Boot and SIP exactly. Make sure to follow the guide.")
+                    logging.info(f"Now building OpenCore EFI is done for {self.constants.computer.real_model}. A new browser tab will open automatically in your default browser of your choice that explains how to disable Secure Boot and SIP exactly. Make sure to follow the guide.")
                     url = "https://github.com/albert-mueller/OpenCore-Legacy-Patcher-T2-Instructions-for-T2-Macs/tree/main"
                     webbrowser.open(url)
                 gui_support.RestartHost(self).restart(message="OpenCore has finished installing to disk.\n\nYou will need to reboot and hold the Option key and select OpenCore/Boot EFI's option.\n\nWould you like to reboot?")


### PR DESCRIPTION
This PR fixes a critical crash during OpenCore EFI installation (`AttributeError: 'InstallOCFrame' object has no attribute 'model'`) that causes the installation to abort before writing to the EFI partition.

It was caused by a recent change that incorrectly referenced `self.model` instead of `self.constants.computer.real_model` when generating the success log on T2 Macs.
Fixes #335.
